### PR TITLE
Fix infinite promptFunc for decryption

### DIFF
--- a/gpg/decrypt/decrypt.go
+++ b/gpg/decrypt/decrypt.go
@@ -65,7 +65,7 @@ func (s *Service) Modify(value []byte) ([]byte, error) {
 				retried = true
 				return []byte(s.pass), nil
 			}
-			return nil, microerror.Maskf(wrongGPGPassword, "Decryption failed with given GPG password")
+			return nil, microerror.Maskf(wrongGPGPasswordError, "Decryption failed with given GPG password")
 		}
 	}()
 	details, err := openpgp.ReadMessage(decoder.Body, nil, promptFunc, nil)

--- a/gpg/decrypt/decrypt.go
+++ b/gpg/decrypt/decrypt.go
@@ -58,9 +58,16 @@ func (s *Service) Modify(value []byte) ([]byte, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	promptFunc := func(keys []openpgp.Key, symmetric bool) ([]byte, error) {
-		return []byte(s.pass), nil
-	}
+	promptFunc := func() func([]openpgp.Key, bool) ([]byte, error) {
+		retried := false
+		return func(keys []openpgp.Key, symmetric bool) ([]byte, error) {
+			if !retried {
+				retried = true
+				return []byte(s.pass), nil
+			}
+			return nil, microerror.Maskf(wrongGPGPassword, "Decryption failed with given GPG password")
+		}
+	}()
 	details, err := openpgp.ReadMessage(decoder.Body, nil, promptFunc, nil)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/gpg/decrypt/error.go
+++ b/gpg/decrypt/error.go
@@ -8,3 +8,10 @@ var invalidConfigError = microerror.New("invalid config")
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var wrongGPGPassword = microerror.New("wrong GPG password")
+
+// IsWrongGPGPassword asserts wrongGPGPassword.
+func IsWrongGPGPassword(err error) bool {
+	return microerror.Cause(err) == wrongGPGPassword
+}

--- a/gpg/decrypt/error.go
+++ b/gpg/decrypt/error.go
@@ -9,9 +9,9 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
-var wrongGPGPassword = microerror.New("wrong GPG password")
+var wrongGPGPasswordError = microerror.New("wrong GPG password")
 
 // IsWrongGPGPassword asserts wrongGPGPassword.
 func IsWrongGPGPassword(err error) bool {
-	return microerror.Cause(err) == wrongGPGPassword
+	return microerror.Cause(err) == wrongGPGPasswordError
 }


### PR DESCRIPTION
When using symmetric encryption, `openpgp.ReadMessage` tries `promptFunc` to get a valid password. As `promptFunc` function returns the same wrong password - `ReadMessage` function goes into infinite loop and does not produce any result. 

Similar issue: https://groups.google.com/forum/#!topic/golang-codereviews/Azs-iwhTue8