### PR TITLE
Encrypt whole strings

### DIFF
--- a/path/path.go
+++ b/path/path.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -185,9 +186,11 @@ func (s *Service) allFromInterface(value interface{}) ([]string, error) {
 			var paths []string
 
 			for k, v := range stringMap {
-				ps, err := s.allFromInterface(v)
-				if err != nil {
-					return nil, microerror.Mask(err)
+				if reflect.TypeOf(v).String() != "string" {
+					ps, err := s.allFromInterface(v)
+					if err != nil {
+						return nil, microerror.Mask(err)
+					}
 				}
 
 				k := s.separatorExpression.ReplaceAllString(k, fmt.Sprintf(`\%s`, s.separator))

--- a/path/path.go
+++ b/path/path.go
@@ -186,8 +186,9 @@ func (s *Service) allFromInterface(value interface{}) ([]string, error) {
 			var paths []string
 
 			for k, v := range stringMap {
+				var ps []string
 				if reflect.TypeOf(v).String() != "string" {
-					ps, err := s.allFromInterface(v)
+					ps, err = s.allFromInterface(v)
 					if err != nil {
 						return nil, microerror.Mask(err)
 					}

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -123,7 +123,7 @@ func Test_Service_All(t *testing.T) {
   }`) + `
 }`),
 			Expected: []string{
-				"k1.k2",
+				"k1",
 			},
 		},
 
@@ -138,7 +138,7 @@ func Test_Service_All(t *testing.T) {
   }`) + `
 }`),
 			Expected: []string{
-				"k1.k2.k3",
+				"k1",
 			},
 		},
 
@@ -153,45 +153,11 @@ func Test_Service_All(t *testing.T) {
   ]`) + `
 }`),
 			Expected: []string{
-				"k1.[0].k2",
+				"k1",
 			},
 		},
 
-		// Test case 10, ensure multiple paths with unnested inline JSON objects can
-		// be found.
-		{
-			InputBytes: []byte(`{
-  "k1": ` + strconv.Quote(`{
-    "k2": "v2",
-    "k3": "v3"
-  }`) + `
-}`),
-			Expected: []string{
-				"k1.k2",
-				"k1.k3",
-			},
-		},
-
-		// Test case 11, ensure multiple paths with nested inline JSON objects can
-		// be found.
-		{
-			InputBytes: []byte(`{
-  "k1": ` + strconv.Quote(`{
-    "k2": {
-      "k3": "v3"
-    },
-    "k4": {
-      "k5": "v5"
-    }
-  }`) + `
-}`),
-			Expected: []string{
-				"k1.k2.k3",
-				"k1.k4.k5",
-			},
-		},
-
-		// Test case 12, ensure multiple paths with unnested inline JSON lists can
+		// Test case 10, ensure multiple paths with unnested inline JSON lists can
 		// be found.
 		{
 			InputBytes: []byte(`{
@@ -205,87 +171,11 @@ func Test_Service_All(t *testing.T) {
   ]`) + `
 }`),
 			Expected: []string{
-				"k1.[0].k2",
-				"k1.[1].k3",
+				"k1",
 			},
 		},
 
-		// Test case 13, ensure single paths with unnested inline YAML objects can
-		// be found.
-		{
-			InputBytes: []byte(`{
-  "k1": "k2: v2"
-}`),
-			Expected: []string{
-				"k1.k2",
-			},
-		},
-
-		// Test case 14, ensure single paths with nested inline YAML objects can be
-		// found.
-		{
-			InputBytes: []byte(`{
-  "k1": ` + strconv.Quote(`k2:
-  k3: v3`) + `
-}`),
-			Expected: []string{
-				"k1.k2.k3",
-			},
-		},
-
-		// Test case 15, ensure single paths with unnested inline YAML lists can be
-		// found.
-		{
-			InputBytes: []byte(`{
-  "k1": "- k2: v2"
-}`),
-			Expected: []string{
-				"k1.[0].k2",
-			},
-		},
-
-		// Test case 16, ensure multiple paths with unnested inline YAML objects can
-		// be found.
-		{
-			InputBytes: []byte(`{
-  "k1": ` + strconv.Quote(`k2: v2
-k3: v3`) + `
-}`),
-			Expected: []string{
-				"k1.k2",
-				"k1.k3",
-			},
-		},
-
-		// Test case 17, ensure multiple paths with nested inline YAML objects can
-		// be found.
-		{
-			InputBytes: []byte(`{
-  "k1": ` + strconv.Quote(`k2:
-  k3: v3
-k4:
-  k5: v5`) + `
-}`),
-			Expected: []string{
-				"k1.k2.k3",
-				"k1.k4.k5",
-			},
-		},
-
-		// Test case 18, ensure multiple paths with unnested inline YAML lists can
-		// be found.
-		{
-			InputBytes: []byte(`{
-  "k1": ` + strconv.Quote(`- k2: v2
-- k3: v3`) + `
-}`),
-			Expected: []string{
-				"k1.[0].k2",
-				"k1.[1].k3",
-			},
-		},
-
-		// Test case 19, ensure paths with separators inside keys can be found.
+		// Test case 11, ensure paths with separators inside keys can be found.
 		{
 			InputBytes: []byte(`{
   "k1": {
@@ -299,7 +189,7 @@ k4:
 			},
 		},
 
-		// Test case 20, ensure a single unnested path can be found, even though its
+		// Test case 12, ensure a single unnested path can be found, even though its
 		// value is empty.
 		{
 			InputBytes: []byte(`{
@@ -310,7 +200,7 @@ k4:
 			},
 		},
 
-		// Test case 21, ensure a single nested path can be found, even though its
+		// Test case 13, ensure a single nested path can be found, even though its
 		// value is empty.
 		{
 			InputBytes: []byte(`{

--- a/value_modifier_test.go
+++ b/value_modifier_test.go
@@ -351,10 +351,11 @@ pass6: 123456-modified1-modified2
     baz: pass2
   foo: pass3
 `,
-			Expected: `pass1: |
+			Expected: `pass1: |-
   bar:
-    baz: pass2-modified1
-  foo: pass3-modified1
+    baz: pass2
+  foo: pass3
+  -modified1
 `,
 		},
 
@@ -378,10 +379,11 @@ pass6: 123456-modified1-modified2
   {
     "block1": {
       "block11": {
-        "pass2": "pass2-modified1"
+        "pass2": "pass2"
       }
     }
   }
+  -modified1
 `,
 		},
 
@@ -482,10 +484,10 @@ pass2: pass2
             {
               "auths": {
                 "quay.io": {
-                  "auth": "magic-modified1"
+                  "auth": "magic"
                 }
               }
-            }
+            }-modified1
 `,
 		},
 


### PR DESCRIPTION
That is something I don't like and would like to change. 
For now `path` package goes through any kind of nested data ignoring actual types. This might be nice but works completely unexpected. 

E.g. if I use `|` string pipe for yaml or `""` string for json value - I expecte this to be string, not a smartly converted structure inside string. 

Current modification wrongly converts e.g. boolean values inside strings. E.g:

```
data:
  value: |
    value2: true
```

after encryption/decryption gives you

```
data:
  value: |
    value2: "true"
```

And that might break apps, which do not have an explicit casting.

another example where current traverse works unexpectedly: 

```
data:
  value: |
  - value2: test
    list:
    - nestedlist
```

after encryption/decryption gives you

```
data:
  value: |
  list: ""
```

My argument here is when I set something to string - I mean that value of that field is a string, not a structure path should try to traverse. So this change makes strings to be strings and encrypted as whole strings during encryption without losing original values on decryption