### PR TITLE
Handle 'null' gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add support for `null` value in nodes, maps and slices.
+
 ## [0.3.0] - 2020-10-21
 
 ### Added

--- a/path/path.go
+++ b/path/path.go
@@ -177,6 +177,10 @@ func (s *Service) Validate(paths []string) error {
 }
 
 func (s *Service) allFromInterface(value interface{}) ([]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
 	// process map
 	{
 		stringMap, err := cast.ToStringMapE(value)
@@ -186,6 +190,11 @@ func (s *Service) allFromInterface(value interface{}) ([]string, error) {
 			var paths []string
 
 			for k, v := range stringMap {
+				if v == nil {
+					paths = append(paths, k)
+					continue
+				}
+
 				var ps []string
 				if reflect.TypeOf(v).String() != "string" {
 					ps, err = s.allFromInterface(v)
@@ -218,6 +227,9 @@ func (s *Service) allFromInterface(value interface{}) ([]string, error) {
 			var paths []string
 
 			for i, v := range slice {
+				if v == nil {
+					continue
+				}
 				ps, err := s.allFromInterface(v)
 				if err != nil {
 					return nil, microerror.Mask(err)

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -497,6 +497,30 @@ k4:
 			Path:     "k.[10].k10",
 			Expected: "v10",
 		},
+
+		// Test case 20, ensure nil values are handled properly - explicit null
+		{
+			InputBytes: []byte(`
+k1:
+  k2: null
+`),
+			Path:     "k1.k2",
+			Expected: nil,
+		},
+
+		// Test case 21, ensure nil values are handled properly - empty value
+		{
+			InputBytes: []byte(`k1:`),
+			Path:       "k1",
+			Expected:   nil,
+		},
+
+		// Test case 22, ensure nil values are handled properly - null value in an array
+		{
+			InputBytes: []byte(`k1: [null]`),
+			Path:       "k1",
+			Expected:   []interface{}{nil},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -214,6 +214,18 @@ func Test_Service_All(t *testing.T) {
 				"k1.k2.k3",
 			},
 		},
+
+		// Test case 14, ensure empty fields are handled (YAML standard allows for such fields).
+		{
+			InputBytes: []byte(`
+k1:
+  k2:
+k3: "v"
+k4: ["a", null "b"]
+k5: null
+`),
+			Expected: []string{"k1.k2", "k3", "k4", "k5"},
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15377

Both JSON and YAML specifications allow for 'null' value. Additionally, YAML supports omitting explicit value altogether (`empty`). Specification mentions such nodes are commonly resolved to `null`:
> Nodes with empty content are interpreted as if they were plain scalars with an empty value. Such nodes are commonly resolved to a “null” value.

## Specification Links
- JSON: https://www.json.org/json-en.html
- YAML `empty`: https://yaml.org/spec/1.2/spec.html#id2786563
- YAML `null`: https://yaml.org/spec/1.2/spec.html#id2803362

## Checklist

- [x] Update changelog in CHANGELOG.md.
