### PR TITLE
Processing slice elements one by one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Modify slice items one by one to prevent loosing the slice content.
+
 ## [0.5.1] - 2022-11-10
 
 ### Fixed

--- a/path/path.go
+++ b/path/path.go
@@ -474,7 +474,7 @@ func (s *Service) setFromInterface(path string, value interface{}, jsonStructure
 			// Empty `recPath` here means the slice does not contain object under given index, since the
 			// further path is empty, i.e. index is of the `[N]` form instead of the `[N].k1.k2...`
 			// form. If we go further with processing in such case, the path will become empty,
-			// and hence the key, and we will end up adding a `{"": modified}` object to the index,
+			// and hence the key, and we will end up adding a `[{"": modified}]` object to the index,
 			// see the `Create new element when the existing jsonStructure doesn't exist.` part of this
 			// function.
 			// We instead use the empty `recPath` as an indicator we are processing regular types here,

--- a/path/path.go
+++ b/path/path.go
@@ -588,20 +588,6 @@ func isYAMLObject(b []byte) bool {
 	return yaml.Unmarshal(b, &m) == nil && !bytes.HasPrefix(b, []byte("-"))
 }
 
-func sanitizeSlice(s []interface{}) []interface{} {
-	sn := make([]interface{}, 0, len(s))
-
-	for _, v := range s {
-		if v == nil {
-			continue
-		}
-
-		sn = append(sn, v)
-	}
-
-	return sn
-}
-
 func toJSON(b []byte) ([]byte, bool, error) {
 	if isJSON(b) {
 		return b, true, nil

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -235,6 +235,15 @@ tolerations:
 `),
 			Expected: []string{"tolerations.[0].effect"},
 		},
+		// Test case 16, ensure slice is handled correctly.
+		{
+			InputBytes: []byte(`
+k1:
+- k2
+- k3
+`),
+			Expected: []string{"k1"},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -529,6 +538,14 @@ k1:
 			InputBytes: []byte(`k1: [null]`),
 			Path:       "k1",
 			Expected:   []interface{}{nil},
+		},
+		// Test case 23, ensure slice is returned correctly by get
+		{
+			InputBytes: []byte(`k1:
+- k2
+- k3`),
+			Path:     "k1",
+			Expected: []interface{}{"k2", "k3"},
 		},
 	}
 
@@ -1138,6 +1155,30 @@ k4:
       "effect": "NoSchedule"
     }
   ]
+}`),
+		},
+		// Test case 30, ensure slice is handled correctly (YAML)
+		{
+			InputBytes: []byte(`k1:
+- k2
+- k3`),
+			Path:  "k1",
+			Value: "modified",
+			Expected: []byte(`k1: modified
+`),
+		},
+		// Test case 30, ensure slice is handled correctly (JSON)
+		{
+			InputBytes: []byte(`{
+  "k1": [
+    "k2",
+	"k3"
+  ]
+}`),
+			Path:  "k1",
+			Value: "modified",
+			Expected: []byte(`{
+  "k1": "modified"
 }`),
 		},
 	}

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -1,7 +1,6 @@
 package path
 
 import (
-	//"fmt"
 	"reflect"
 	"strconv"
 	"testing"
@@ -244,6 +243,16 @@ args:
 - arg2
 `),
 			Expected: []string{"args.[0]", "args.[1]"},
+		},
+		// Test case 17, ensure slice is handled correctly, mixed elements
+		{
+			InputBytes: []byte(`
+args:
+- arg1
+- arg2
+- arg3: heh
+`),
+			Expected: []string{"args.[0]", "args.[1]", "args.[2].arg3"},
 		},
 	}
 
@@ -565,6 +574,24 @@ k1:
 - 8080`),
 			Path:     "k1.[1]",
 			Expected: "null",
+		},
+		// Test case 26, ensure slice is returned correctly by get; strings mixed with objects; get object
+		{
+			InputBytes: []byte(`k1:
+- k2
+- k3
+- k4: value`),
+			Path:     "k1.[2].k4",
+			Expected: "value",
+		},
+		// Test case 27, ensure slice is returned correctly by get; strings mixed with objects; get string
+		{
+			InputBytes: []byte(`k1:
+- k2
+- k3
+- k4: value`),
+			Path:     "k1.[1]",
+			Expected: "k3",
 		},
 	}
 

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -254,6 +254,31 @@ args:
 `),
 			Expected: []string{"args.[0]", "args.[1]", "args.[2].arg3"},
 		},
+		// Test case 18, ensure slice is handled correctly, even more mixed elements
+		{
+			InputBytes: []byte(`
+args:
+- arg1
+- arg2
+- arg3:
+    a1: v1
+    a2:
+    - b1
+    - b2: v2
+    - b3:
+      - c1
+      - c2
+`),
+			Expected: []string{
+				"args.[0]",
+				"args.[1]",
+				"args.[2].arg3.a1",
+				"args.[2].arg3.a2.[0]",
+				"args.[2].arg3.a2.[1].b2",
+				"args.[2].arg3.a2.[2].b3.[0]",
+				"args.[2].arg3.a2.[2].b3.[1]",
+			},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -592,6 +617,40 @@ k1:
 - k4: value`),
 			Path:     "k1.[1]",
 			Expected: "k3",
+		},
+		{
+			InputBytes: []byte(`
+args:
+- arg1
+- arg2
+- arg3:
+    a1: v1
+    a2:
+    - b1
+    - b2: v2
+    - b3:
+      - c1
+      - c2
+`),
+			Path:     "args.[2].arg3.a2.[1].b2",
+			Expected: "v2",
+		},
+		{
+			InputBytes: []byte(`
+args:
+- arg1
+- arg2
+- arg3:
+    a1: v1
+    a2:
+    - b1
+    - b2: v2
+    - b3:
+      - c1
+      - c2
+`),
+			Path:     "args.[2].arg3.a2.[2].b3.[0]",
+			Expected: "c1",
 		},
 	}
 

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -607,7 +607,6 @@ k1:
 		if err != nil {
 			t.Fatal("test", i+1, "expected", nil, "got", err)
 		}
-		//fmt.Println(reflect.TypeOf(tc.Expected), reflect.TypeOf(output))
 		if !reflect.DeepEqual(tc.Expected, output) {
 			t.Fatal("test", i+1, "expected", tc.Expected, "got", output)
 		}

--- a/value_modifier_test.go
+++ b/value_modifier_test.go
@@ -544,6 +544,19 @@ pass2: pass2
             }
 `,
 		},
+		// Test case 12, modifier operating on a slice
+		{
+			ValueModifiers: []ValueModifier{
+				testModifier1{},
+			},
+			IgnoreFields: []string{},
+			SelectFields: []string{},
+			Input: `k1:
+- k2
+- k3`,
+			Expected: `k1: -modified1
+`,
+		},
 	}
 
 	for i, testCase := range testCases {

--- a/value_modifier_test.go
+++ b/value_modifier_test.go
@@ -554,7 +554,45 @@ pass2: pass2
 			Input: `k1:
 - k2
 - k3`,
-			Expected: `k1: -modified1
+			Expected: `k1:
+- k2-modified1
+- k3-modified1
+`,
+		},
+		// Test case 13, modifier operating on a slice, mixed values
+		{
+			ValueModifiers: []ValueModifier{
+				testModifier1{},
+			},
+			IgnoreFields: []string{},
+			SelectFields: []string{},
+			Input: `k1:
+- k2
+- k3
+- 8080`,
+			Expected: `k1:
+- k2-modified1
+- k3-modified1
+- 8080-modified1
+`,
+		},
+		// Test case 14, modifier operating on a slice, null
+		{
+			ValueModifiers: []ValueModifier{
+				testModifier1{},
+			},
+			IgnoreFields: []string{},
+			SelectFields: []string{},
+			Input: `k1:
+- k2
+- k3
+- null
+- 8080`,
+			Expected: `k1:
+- k2-modified1
+- k3-modified1
+- null
+- 8080-modified1
 `,
 		},
 	}


### PR DESCRIPTION
## Description

Towards: https://github.com/giantswarm/giantswarm/issues/24490

Long story short, so far slices not containing any objects inside have been handled as a whole, what doesn't work well with the [ToString](https://github.com/giantswarm/valuemodifier/blob/450369d2183a518ba962e72f8b431d697415b843/value_modifier.go#L127) upon traversing, as it replaces them with empty string. Given a choice to either fix the traverser and make it still work with a slice as a whole, or to make it more granular and process slice items one by one, I decided to choose the latter and put some minor changes to the path package. It made sense especially we process items one by one when they are objects.

### Previously

```yaml
args:
- arg1
- arg2
```

Calling for all paths return:
* `args`

Getting the `args` path return:
* `[]interface{}{"arg1", "arg2"}`

Setting the `args` path return:
* `args: modified`

### Now

```yaml
args:
- arg1
- arg2
```

Calling for all paths return:
* `args.[0]`
* `args.[1]`

Getting the `args.[0]` path return:
* `arg1`

Setting the `args.[1]` path return:
```yaml
args:
- arg1
- modified
```


## Checklist

- [x] Update changelog in CHANGELOG.md.
